### PR TITLE
fix(captcha): 600ms 超时误判丢发码参数 + 超时后孤儿拼图（发码全挂根因）

### DIFF
--- a/packages/vote/src/common/lib/aliyunCaptcha.ts
+++ b/packages/vote/src/common/lib/aliyunCaptcha.ts
@@ -83,7 +83,9 @@ export async function verifyHuman(): Promise<string | null | undefined> {
       fail: (): void => undefined,
       onClose: (): void => done(null),
       getInstance: (instance: any): void => {
-        if (inited) return
+        // settled=超时兜底已放弃本轮：不再 show()，否则会弹出一个
+        // 结果无人接收的孤儿拼图（用户拖完 success 被吞、界面无反应）
+        if (inited || settled) return
         inited = true
         capInstance = instance
         if (capInstance && typeof capInstance.show === 'function') {
@@ -94,12 +96,15 @@ export async function verifyHuman(): Promise<string | null | undefined> {
       language: 'cn',
     })
 
-    // 极端兜底：若 getInstance 始终不触发，600ms 后放弃
+    // 极端兜底：若 getInstance 始终不触发，5s 后放弃。
+    // 不能太短：SDK 初始化含设备指纹采集（官方建议脚本加载到验证 ≥2s），
+    // 慢网络下 getInstance 常晚于 600ms——超时误判会以 undefined 结算，
+    // LoginBox 只挡 null，无参请求直接打到后端报 CAPTCHA_REQUIRED
     setTimeout(() => {
       if (inited || settled) return
       // still no instance — SDK may have silently failed
       done(undefined)
-    }, 600)
+    }, 5000)
   })
 
   return pendingPromise


### PR DESCRIPTION
## 症状（测试机 :8082，07-21 起）

登录页点「发送验证码」→ 拼图正常弹出、能拖完 → **拖完后无任何反应**，console 报 `CAPTCHA_REQUIRED`（或偶发 `CAPTCHA_UNAVAILABLE`），弹「请完成人机验证」。真人验收（07-17，dev 旧实现）时是好的。

## 根因（`4db0597` 引入的两个叠加缺陷）

1. **600ms 兜底超时太短**：SDK 初始化含设备指纹采集（官方建议脚本加载到发起验证 ≥2s），慢网络下 `getInstance` 常晚于 600ms。超时把 Promise 以 `undefined` 结算——但 `undefined` 在 `verifyHuman` 契约里是「脚本加载失败、降级无参请求」的语义，`LoginBox.vue` 只挡 `null` → **发码 mutation 不带 `captchaVerifyParam` 就发出去了**，后端闸门（fail-closed）报 `CAPTCHA_REQUIRED`。已抓到实际的无参失败请求确认。
2. **超时结算后没有拦住晚到的 `getInstance`**：实例晚到照样 `show()`，弹出一个「结果无人接收」的孤儿拼图——用户拖完，`success` 回调进来时 Promise 早已 settled，被 `done()` 的幂等保护静默吞掉，界面毫无反应。

排查中已实测排除其他环节：后端→阿里云通路/AK/SceneId 健康（假参数能拿到正常判定 F003/F014）、Nacos 六键未变、部署 bundle 的 prefix/SceneId 与后端一致。

## 修复

- `getInstance` 回调加 `settled` 检查：超时放弃后不再弹孤儿拼图。
- 兜底超时 600ms → 5000ms：给慢网络下的正常初始化留够时间；真正的 SDK 静默失败仍会在 5s 后按原语义降级。

共 +8/-3，只动 `packages/vote/src/common/lib/aliyunCaptcha.ts`。

## 验证建议（合并自动重新部署 :8082 后）

1. 登录页点「发送验证码」→ 拼图弹出 → 拖完 → 应进入倒计时并收到短信。
2. 若仍见 `CAPTCHA_UNAVAILABLE`：Network 里该 graphql 响应的 `extensions.error_message`/`upstream_response_string` 会带阿里云原始错误码，可直接定位（后端侧我们已确认健康）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
