### PR TITLE
renko_dev → dev：dev proxy 修复 + 届数收敛 + zfq 静态审查批次

### DIFF
--- a/.github/workflows/result-image.yml
+++ b/.github/workflows/result-image.yml
@@ -18,6 +18,7 @@ on:
     branches:
       - zfq_dev_fe
       - dev
+      - renko_dev  # 我方工作分支(push 触发读被推分支的 workflow,此行只在 renko_dev 上生效)
     paths:
       - '.github/workflows/result-image.yml'
       - 'Dockerfile.result.template'

--- a/Dockerfile.vote.template
+++ b/Dockerfile.vote.template
@@ -46,14 +46,11 @@ FROM nginx:alpine
 # /v11-be/ 为过渡兼容块（当前已部署前端仍打 v11），前端全部切到 v12 后删除。
 #
 # 2026-08-05 优化:
-# - resolver: 每 10s 重新解析 thvote-backend DNS，防止后端容器重启 IP 变更导致代理失败
 # - proxy_connect_timeout / proxy_read_timeout: 防止慢请求长时间占用连接
 # - proxy_next_upstream: 后端连接失败/超时自动重试
 # - gzip: 压缩静态资源减少传输时间
-# - 使用变量 $backend_upstream 触发 nginx 动态 DNS 解析 (resolver)
 RUN echo 'server { \
     listen 8082; \
-    resolver 127.0.0.11 valid=10s ipv6=off; \
     gzip on; \
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml text/javascript; \
     gzip_min_length 256; \
@@ -62,8 +59,7 @@ RUN echo 'server { \
         try_files $uri /index.html; \
     } \
     location /v12-be/vote-objects/ { \
-        set $backend_upstream thvote-backend:8000; \
-        proxy_pass http://$backend_upstream/api/v1/vote-objects/; \
+        proxy_pass http://thvote-backend:8000/api/v1/vote-objects/; \
         proxy_http_version 1.1; \
         proxy_set_header Host $host; \
         proxy_set_header X-Real-IP $remote_addr; \
@@ -74,8 +70,7 @@ RUN echo 'server { \
         proxy_next_upstream error timeout http_502 http_503 http_504; \
     } \
     location /v12-be/questionnaire/ { \
-        set $backend_upstream thvote-backend:8000; \
-        proxy_pass http://$backend_upstream/api/v1/questionnaire/; \
+        proxy_pass http://thvote-backend:8000/api/v1/questionnaire/; \
         proxy_http_version 1.1; \
         proxy_set_header Host $host; \
         proxy_set_header X-Real-IP $remote_addr; \
@@ -86,8 +81,7 @@ RUN echo 'server { \
         proxy_next_upstream error timeout http_502 http_503 http_504; \
     } \
     location = /v12-be/doujin/api { \
-        set $backend_upstream thvote-backend:8000; \
-        proxy_pass http://$backend_upstream/api/v1/scraper/scrape; \
+        proxy_pass http://thvote-backend:8000/api/v1/scraper/scrape; \
         proxy_http_version 1.1; \
         proxy_set_header Host $host; \
         proxy_set_header X-Real-IP $remote_addr; \
@@ -98,8 +92,7 @@ RUN echo 'server { \
         proxy_next_upstream error timeout http_502 http_503 http_504; \
     } \
     location /v12-be/ { \
-        set $backend_upstream thvote-backend:8000; \
-        proxy_pass http://$backend_upstream/; \
+        proxy_pass http://thvote-backend:8000/; \
         proxy_http_version 1.1; \
         proxy_set_header Host $host; \
         proxy_set_header X-Real-IP $remote_addr; \
@@ -110,8 +103,7 @@ RUN echo 'server { \
         proxy_next_upstream error timeout http_502 http_503 http_504; \
     } \
     location /v11-be/ { \
-        set $backend_upstream thvote-backend:8000; \
-        proxy_pass http://$backend_upstream/; \
+        proxy_pass http://thvote-backend:8000/; \
         proxy_http_version 1.1; \
         proxy_set_header Host $host; \
         proxy_set_header X-Real-IP $remote_addr; \

--- a/Dockerfile.vote.template
+++ b/Dockerfile.vote.template
@@ -44,51 +44,82 @@ FROM nginx:alpine
 # 监听 8082（与 test 环境配置一致）
 # v12 路由：精确前缀块转发到后端 /api/v1/*，兜底块处理 graphql 等根路径端点。
 # /v11-be/ 为过渡兼容块（当前已部署前端仍打 v11），前端全部切到 v12 后删除。
+#
+# 2026-08-05 优化:
+# - resolver: 每 10s 重新解析 thvote-backend DNS，防止后端容器重启 IP 变更导致代理失败
+# - proxy_connect_timeout / proxy_read_timeout: 防止慢请求长时间占用连接
+# - proxy_next_upstream: 后端连接失败/超时自动重试
+# - gzip: 压缩静态资源减少传输时间
+# - 使用变量 $backend_upstream 触发 nginx 动态 DNS 解析 (resolver)
 RUN echo 'server { \
     listen 8082; \
+    resolver 127.0.0.11 valid=10s ipv6=off; \
+    gzip on; \
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml text/javascript; \
+    gzip_min_length 256; \
     location / { \
         root /usr/share/nginx/html; \
         try_files $uri /index.html; \
     } \
     location /v12-be/vote-objects/ { \
-        proxy_pass http://thvote-backend:8000/api/v1/vote-objects/; \
+        set $backend_upstream thvote-backend:8000; \
+        proxy_pass http://$backend_upstream/api/v1/vote-objects/; \
         proxy_http_version 1.1; \
         proxy_set_header Host $host; \
         proxy_set_header X-Real-IP $remote_addr; \
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; \
         proxy_set_header X-Forwarded-Proto $scheme; \
+        proxy_connect_timeout 5s; \
+        proxy_read_timeout 30s; \
+        proxy_next_upstream error timeout http_502 http_503 http_504; \
     } \
     location /v12-be/questionnaire/ { \
-        proxy_pass http://thvote-backend:8000/api/v1/questionnaire/; \
+        set $backend_upstream thvote-backend:8000; \
+        proxy_pass http://$backend_upstream/api/v1/questionnaire/; \
         proxy_http_version 1.1; \
         proxy_set_header Host $host; \
         proxy_set_header X-Real-IP $remote_addr; \
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; \
         proxy_set_header X-Forwarded-Proto $scheme; \
+        proxy_connect_timeout 5s; \
+        proxy_read_timeout 30s; \
+        proxy_next_upstream error timeout http_502 http_503 http_504; \
     } \
     location = /v12-be/doujin/api { \
-        proxy_pass http://thvote-backend:8000/api/v1/scraper/scrape; \
+        set $backend_upstream thvote-backend:8000; \
+        proxy_pass http://$backend_upstream/api/v1/scraper/scrape; \
         proxy_http_version 1.1; \
         proxy_set_header Host $host; \
         proxy_set_header X-Real-IP $remote_addr; \
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; \
         proxy_set_header X-Forwarded-Proto $scheme; \
+        proxy_connect_timeout 5s; \
+        proxy_read_timeout 30s; \
+        proxy_next_upstream error timeout http_502 http_503 http_504; \
     } \
     location /v12-be/ { \
-        proxy_pass http://thvote-backend:8000/; \
+        set $backend_upstream thvote-backend:8000; \
+        proxy_pass http://$backend_upstream/; \
         proxy_http_version 1.1; \
         proxy_set_header Host $host; \
         proxy_set_header X-Real-IP $remote_addr; \
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; \
         proxy_set_header X-Forwarded-Proto $scheme; \
+        proxy_connect_timeout 5s; \
+        proxy_read_timeout 30s; \
+        proxy_next_upstream error timeout http_502 http_503 http_504; \
     } \
     location /v11-be/ { \
-        proxy_pass http://thvote-backend:8000/; \
+        set $backend_upstream thvote-backend:8000; \
+        proxy_pass http://$backend_upstream/; \
         proxy_http_version 1.1; \
         proxy_set_header Host $host; \
         proxy_set_header X-Real-IP $remote_addr; \
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; \
         proxy_set_header X-Forwarded-Proto $scheme; \
+        proxy_connect_timeout 5s; \
+        proxy_read_timeout 30s; \
+        proxy_next_upstream error timeout http_502 http_503 http_504; \
     } \
 }' > /etc/nginx/conf.d/default.conf
 

--- a/packages/navigator/vite.config.ts
+++ b/packages/navigator/vite.config.ts
@@ -5,8 +5,6 @@ import components from 'unplugin-vue-components/vite'
 import autoImport from 'unplugin-auto-import/vite'
 import unocss from 'unocss/vite'
 
-const HOST = 'http://localhost'
-
 export default defineConfig(({ command }) => {
   return {
     resolve: {
@@ -26,14 +24,9 @@ export default defineConfig(({ command }) => {
       unocss(),
     ],
     server: {
-      proxy: {
-        '/nav-be': {
-          target: `${HOST}/nav-be`,
-          changeOrigin: true,
-          secure: false,
-          rewrite: (path: string) => path.replace(/^\/nav-be/, ''),
-        },
-      },
+      // navigator 是纯静态站，没有后端调用：源码零处引用 /nav-be，
+      // Dockerfile.navigator.template 也只有 `location /`、没有任何 proxy 块。
+      // 原先那条 /nav-be → localhost:80 是残留配置，已移除。
     },
     build: {
       sourcemap: true,

--- a/packages/result/index.html
+++ b/packages/result/index.html
@@ -4,7 +4,8 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>投票结果 - 第11回 中文东方人气投票</title>
+    <!-- 静态标题不带届数(防跨届过期);运行时由 setSiteTitle 按 shared voteYear 覆盖 -->
+    <title>投票结果 - 中文东方人气投票</title>
   </head>
   <body style="min-width: 320px;">
     <div id="app"></div>

--- a/packages/result/src/components/AdvancedSearch.vue
+++ b/packages/result/src/components/AdvancedSearch.vue
@@ -293,7 +293,7 @@ const props = defineProps({
   open: {
     type: Boolean,
     default: false,
-    requred: true,
+    required: true,
   },
   filtermode: {
     type: Boolean,

--- a/packages/result/src/components/GraphRadar.vue
+++ b/packages/result/src/components/GraphRadar.vue
@@ -30,7 +30,7 @@ const props = defineProps<{
   data: GraphDataRadar[]
   voteTotal: number
   voteMale: number
-  voteFamale: number
+  voteFemale: number
 }>()
 
 echarts.use([
@@ -100,7 +100,7 @@ const dataWithRelativeScale = computed<GraphDataRadar[]>(() => {
     relatedData[0].value.push((item * props.voteTotal) / props.voteMale)
   })
   props.data[2].value.map((item) => {
-    relatedData[1].value.push((item * props.voteTotal) / props.voteFamale)
+    relatedData[1].value.push((item * props.voteTotal) / props.voteFemale)
   })
   return props.data.concat(relatedData)
 })

--- a/packages/result/src/components/Questionnaire.vue
+++ b/packages/result/src/components/Questionnaire.vue
@@ -93,6 +93,7 @@
   </div>
 </template>
 <script lang="ts" setup>
+import { voteStart, voteYear } from '@/lib/voteYear'
 import { gql, useLazyQuery } from '@/composables/graphql'
 import type { Query } from '@/composables/graphql'
 import NProgress from 'nprogress'
@@ -216,13 +217,13 @@ const {
   `,
   props.q === ''
     ? {
-        voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-        voteYear: 11,
+        voteStart,
+        voteYear,
         questionsOfInterest: allQuestionnaireIDList.value,
       }
     : {
-        voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-        voteYear: 11,
+        voteStart,
+        voteYear,
         query: props.q,
         questionsOfInterest: allQuestionnaireIDList.value,
       }
@@ -282,13 +283,13 @@ async function QuestionnaireDetail(q: string): Promise<void> {
       undefined,
       q === ''
         ? {
-            voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-            voteYear: 11,
+            voteStart,
+            voteYear,
             questionsOfInterest: allQuestionnaireIDList.value,
           }
         : {
-            voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-            voteYear: 11,
+            voteStart,
+            voteYear,
             query: q,
             questionsOfInterest: allQuestionnaireIDList.value,
           }
@@ -298,13 +299,13 @@ async function QuestionnaireDetail(q: string): Promise<void> {
       variables:
         q === ''
           ? {
-              voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-              voteYear: 11,
+              voteStart,
+              voteYear,
               questionsOfInterest: allQuestionnaireIDList.value,
             }
           : {
-              voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-              voteYear: 11,
+              voteStart,
+              voteYear,
               query: q,
               questionsOfInterest: allQuestionnaireIDList.value,
             },

--- a/packages/result/src/components/Questionnaire.vue
+++ b/packages/result/src/components/Questionnaire.vue
@@ -78,13 +78,13 @@
           :data="getDataRadar(item)"
           :vote-total="item.totalAnswers"
           :vote-male="item.totalMale"
-          :vote-famale="item.totalFemale"
+          :vote-female="item.totalFemale"
           v-else-if="item.type === 'Multiple'"
           class="max-w-4xl pt-3 mx-auto"
         />
         <router-link
           class="py-3 inline-block"
-          :to="'QuestionnaireInputDetail?qid=' + item.questionId + '&q=' + props.q"
+          :to="'/QuestionnaireInputDetail?qid=' + item.questionId + '&q=' + props.q"
           v-else-if="item.type === 'Input'"
           >点击这里查看全部回答</router-link
         >

--- a/packages/result/src/components/VoteSelect.vue
+++ b/packages/result/src/components/VoteSelect.vue
@@ -51,7 +51,7 @@ const props = defineProps({
   itemList: {
     type: Array as PropType<SelectList[]>,
     default: () => [],
-    requred: true,
+    required: true,
   },
   selected: {
     type: Object as PropType<SelectList>,
@@ -61,7 +61,7 @@ const props = defineProps({
         value: '',
       }
     },
-    requred: true,
+    required: true,
   },
   selectedName: {
     type: String,

--- a/packages/result/src/lib/voteYear.ts
+++ b/packages/result/src/lib/voteYear.ts
@@ -1,3 +1,3 @@
-import { voteYear } from '@touhou-vote/shared/data/voteYear'
+import { voteStart, voteYear } from '@touhou-vote/shared/data/voteYear'
 
-export { voteYear }
+export { voteStart, voteYear }

--- a/packages/result/src/pages/CharacterReason.vue
+++ b/packages/result/src/pages/CharacterReason.vue
@@ -49,6 +49,7 @@
   </div>
 </template>
 <script lang="ts" setup>
+import { voteStart, voteYear } from '@/lib/voteYear'
 import { useRoute } from 'vue-router'
 import { gql, useQuery } from '@/composables/graphql'
 import type { Query } from '@/composables/graphql'
@@ -94,13 +95,13 @@ const { result, loading, onError } = useQuery<Query>(
   `,
   getAdditionalConstraintString(additionalConstraint.value) === ''
     ? {
-        voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-        voteYear: 11,
+        voteStart,
+        voteYear,
         rank: characterRank.value,
       }
     : {
-        voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-        voteYear: 11,
+        voteStart,
+        voteYear,
         rank: characterRank.value,
         query: getAdditionalConstraintString(additionalConstraint.value),
       }

--- a/packages/result/src/pages/Couple.vue
+++ b/packages/result/src/pages/Couple.vue
@@ -43,6 +43,7 @@
 </template>
 
 <script lang="ts" setup>
+import { voteStart, voteYear } from '@/lib/voteYear'
 import { gql, useQuery } from '@/composables/graphql'
 import type { Query } from '@/composables/graphql'
 import NProgress from 'nprogress'
@@ -77,8 +78,8 @@ const {
   `,
 
   {
-    voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-    voteYear: 11,
+    voteStart,
+    voteYear,
   },
   {
     fetchPolicy: 'network-only',

--- a/packages/result/src/pages/CoupleDetail.vue
+++ b/packages/result/src/pages/CoupleDetail.vue
@@ -146,6 +146,7 @@
 </template>
 
 <script lang="ts" setup>
+import { voteStart, voteYear } from '@/lib/voteYear'
 import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 import { gql, useQuery } from '@/composables/graphql'
@@ -366,13 +367,13 @@ watch(additionalConstraint, () => {
     variables:
       getAdditionalConstraintString(additionalConstraint.value) === ''
         ? {
-            voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-            voteYear: 11,
+            voteStart,
+            voteYear,
           }
         : {
             query: getAdditionalConstraintString(additionalConstraint.value),
-            voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-            voteYear: 11,
+            voteStart,
+            voteYear,
           },
     updateQuery(previousQueryResult, { fetchMoreResult }) {
       if (!fetchMoreResult) return previousQueryResult
@@ -388,13 +389,13 @@ watch(queryword, () => {
     variables:
       queryword.value === ''
         ? {
-            voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-            voteYear: 11,
+            voteStart,
+            voteYear,
           }
         : {
             query: queryword.value,
-            voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-            voteYear: 11,
+            voteStart,
+            voteYear,
           },
     updateQuery(previousQueryResult, { fetchMoreResult }) {
       if (!fetchMoreResult) return previousQueryResult
@@ -410,23 +411,23 @@ watch(GUIMode, () => {
     variables: GUIMode.value
       ? getAdditionalConstraintString(additionalConstraint.value) === ''
         ? {
-            voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-            voteYear: 11,
+            voteStart,
+            voteYear,
           }
         : {
             query: getAdditionalConstraintString(additionalConstraint.value),
-            voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-            voteYear: 11,
+            voteStart,
+            voteYear,
           }
       : queryword.value === ''
       ? {
-          voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-          voteYear: 11,
+          voteStart,
+          voteYear,
         }
       : {
           query: queryword.value,
-          voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-          voteYear: 11,
+          voteStart,
+          voteYear,
         },
     updateQuery(previousQueryResult, { fetchMoreResult }) {
       if (!fetchMoreResult) return previousQueryResult
@@ -491,23 +492,23 @@ const {
   GUIMode.value
     ? getAdditionalConstraintString(additionalConstraint.value) === ''
       ? {
-          voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-          voteYear: 11,
+          voteStart,
+          voteYear,
         }
       : {
           query: getAdditionalConstraintString(additionalConstraint.value),
-          voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-          voteYear: 11,
+          voteStart,
+          voteYear,
         }
     : queryword.value === ''
     ? {
-        voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-        voteYear: 11,
+        voteStart,
+        voteYear,
       }
     : {
         query: queryword.value,
-        voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-        voteYear: 11,
+        voteStart,
+        voteYear,
       },
   {
     fetchPolicy: 'network-only',

--- a/packages/result/src/pages/CoupleReason.vue
+++ b/packages/result/src/pages/CoupleReason.vue
@@ -97,6 +97,7 @@
   </div>
 </template>
 <script lang="ts" setup>
+import { voteStart, voteYear } from '@/lib/voteYear'
 import { useRoute } from 'vue-router'
 import { gql, useQuery } from '@/composables/graphql'
 import type { Query } from '@/composables/graphql'
@@ -155,13 +156,13 @@ const { result, loading, onError } = useQuery<Query>(
   `,
   getAdditionalConstraintString(additionalConstraint.value) === ''
     ? {
-        voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-        voteYear: 11,
+        voteStart,
+        voteYear,
         rank: coupleRank.value,
       }
     : {
-        voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-        voteYear: 11,
+        voteStart,
+        voteYear,
         rank: coupleRank.value,
         query: getAdditionalConstraintString(additionalConstraint.value),
       }

--- a/packages/result/src/pages/CoupleSingleDetail.vue
+++ b/packages/result/src/pages/CoupleSingleDetail.vue
@@ -110,6 +110,7 @@
   </div>
 </template>
 <script lang="ts" setup>
+import { voteStart, voteYear } from '@/lib/voteYear'
 import { useRoute } from 'vue-router'
 import { gql, useQuery } from '@/composables/graphql'
 import type { Query } from '@/composables/graphql'
@@ -179,13 +180,13 @@ const { result, loading, onError } = useQuery<Query>(
   `,
   getAdditionalConstraintString(additionalConstraint.value) === ''
     ? {
-        voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-        voteYear: 11,
+        voteStart,
+        voteYear,
         rank: coupleRank.value,
       }
     : {
-        voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-        voteYear: 11,
+        voteStart,
+        voteYear,
         rank: coupleRank.value,
         query: getAdditionalConstraintString(additionalConstraint.value),
       }

--- a/packages/result/src/pages/Music.vue
+++ b/packages/result/src/pages/Music.vue
@@ -43,6 +43,7 @@
 </template>
 
 <script lang="ts" setup>
+import { voteStart, voteYear } from '@/lib/voteYear'
 import { gql, useQuery } from '@/composables/graphql'
 import type { Query } from '@/composables/graphql'
 import NProgress from 'nprogress'
@@ -92,8 +93,8 @@ const {
   `,
 
   {
-    voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-    voteYear: 11,
+    voteStart,
+    voteYear,
   },
   {
     fetchPolicy: 'network-only',

--- a/packages/result/src/pages/MusicCompare.vue
+++ b/packages/result/src/pages/MusicCompare.vue
@@ -143,6 +143,7 @@
 </template>
 
 <script lang="ts" setup>
+import { voteStart, voteYear } from '@/lib/voteYear'
 import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 import { gql, useQuery } from '@/composables/graphql'
@@ -489,8 +490,8 @@ const {
     }
   `,
   {
-    voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-    voteYear: 11,
+    voteStart,
+    voteYear,
   },
   {
     fetchPolicy: 'network-only',

--- a/packages/result/src/pages/MusicDetail.vue
+++ b/packages/result/src/pages/MusicDetail.vue
@@ -146,6 +146,7 @@
 </template>
 
 <script lang="ts" setup>
+import { voteStart, voteYear } from '@/lib/voteYear'
 import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 import { gql, useQuery } from '@/composables/graphql'
@@ -359,13 +360,13 @@ watch(additionalConstraint, () => {
     variables:
       getAdditionalConstraintString(additionalConstraint.value) === ''
         ? {
-            voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-            voteYear: 11,
+            voteStart,
+            voteYear,
           }
         : {
             query: getAdditionalConstraintString(additionalConstraint.value),
-            voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-            voteYear: 11,
+            voteStart,
+            voteYear,
           },
     updateQuery(previousQueryResult, { fetchMoreResult }) {
       if (!fetchMoreResult) return previousQueryResult
@@ -381,13 +382,13 @@ watch(queryword, () => {
     variables:
       queryword.value === ''
         ? {
-            voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-            voteYear: 11,
+            voteStart,
+            voteYear,
           }
         : {
             query: queryword.value,
-            voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-            voteYear: 11,
+            voteStart,
+            voteYear,
           },
     updateQuery(previousQueryResult, { fetchMoreResult }) {
       if (!fetchMoreResult) return previousQueryResult
@@ -403,23 +404,23 @@ watch(GUIMode, () => {
     variables: GUIMode.value
       ? getAdditionalConstraintString(additionalConstraint.value) === ''
         ? {
-            voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-            voteYear: 11,
+            voteStart,
+            voteYear,
           }
         : {
             query: getAdditionalConstraintString(additionalConstraint.value),
-            voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-            voteYear: 11,
+            voteStart,
+            voteYear,
           }
       : queryword.value === ''
       ? {
-          voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-          voteYear: 11,
+          voteStart,
+          voteYear,
         }
       : {
           query: queryword.value,
-          voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-          voteYear: 11,
+          voteStart,
+          voteYear,
         },
     updateQuery(previousQueryResult, { fetchMoreResult }) {
       if (!fetchMoreResult) return previousQueryResult
@@ -479,23 +480,23 @@ const {
   GUIMode.value
     ? getAdditionalConstraintString(additionalConstraint.value) === ''
       ? {
-          voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-          voteYear: 11,
+          voteStart,
+          voteYear,
         }
       : {
           query: getAdditionalConstraintString(additionalConstraint.value),
-          voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-          voteYear: 11,
+          voteStart,
+          voteYear,
         }
     : queryword.value === ''
     ? {
-        voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-        voteYear: 11,
+        voteStart,
+        voteYear,
       }
     : {
         query: queryword.value,
-        voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-        voteYear: 11,
+        voteStart,
+        voteYear,
       },
   {
     fetchPolicy: 'network-only',

--- a/packages/result/src/pages/MusicEvolution.vue
+++ b/packages/result/src/pages/MusicEvolution.vue
@@ -91,6 +91,7 @@
   </div>
 </template>
 <script lang="ts" setup>
+import { voteStart, voteYear } from '@/lib/voteYear'
 import { watchEffect } from 'vue'
 import NProgress from 'nprogress'
 import { gql, useLazyQuery, useQuery } from '@/composables/graphql'
@@ -154,15 +155,15 @@ async function getMusicEvolution(): Promise<void> {
   trendMusicNumber.value = musicsForEvolution.value.length
   if (queryMusicEbvolutionForceDisabled.value)
     loadMusicEbvolution(undefined, {
-      voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-      voteYear: 11,
+      voteStart,
+      voteYear,
       names: musicsForEvolution.value,
     })
   else
     queryMusicEbvolutionMore({
       variables: {
-        voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-        voteYear: 11,
+        voteStart,
+        voteYear,
         names: musicsForEvolution.value,
       },
       updateQuery(previousQueryResult, { fetchMoreResult }) {
@@ -194,8 +195,8 @@ const {
     }
   `,
   {
-    voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-    voteYear: 11,
+    voteStart,
+    voteYear,
     names: musicsForEvolution.value,
   },
   {
@@ -248,8 +249,8 @@ const {
     }
   `,
   {
-    voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-    voteYear: 11,
+    voteStart,
+    voteYear,
   },
   {
     fetchPolicy: 'network-only',

--- a/packages/result/src/pages/MusicReason.vue
+++ b/packages/result/src/pages/MusicReason.vue
@@ -52,6 +52,7 @@
   </div>
 </template>
 <script lang="ts" setup>
+import { voteStart, voteYear } from '@/lib/voteYear'
 import { useRoute } from 'vue-router'
 import { gql, useQuery } from '@/composables/graphql'
 import type { Query } from '@/composables/graphql'
@@ -92,13 +93,13 @@ const { result, loading, onError } = useQuery<Query>(
   `,
   getAdditionalConstraintString(additionalConstraint.value) === ''
     ? {
-        voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-        voteYear: 11,
+        voteStart,
+        voteYear,
         rank: musicRank.value,
       }
     : {
-        voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-        voteYear: 11,
+        voteStart,
+        voteYear,
         rank: musicRank.value,
         query: getAdditionalConstraintString(additionalConstraint.value),
       }

--- a/packages/result/src/pages/MusicSingleDetail.vue
+++ b/packages/result/src/pages/MusicSingleDetail.vue
@@ -66,6 +66,7 @@
   </div>
 </template>
 <script lang="ts" setup>
+import { voteStart, voteYear } from '@/lib/voteYear'
 import { useRoute } from 'vue-router'
 import { gql, useQuery } from '@/composables/graphql'
 import type { Query } from '@/composables/graphql'
@@ -119,13 +120,13 @@ const { result, loading, onError } = useQuery<Query>(
   `,
   getAdditionalConstraintString(additionalConstraint.value) === ''
     ? {
-        voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-        voteYear: 11,
+        voteStart,
+        voteYear,
         rank: musicRank.value,
       }
     : {
-        voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-        voteYear: 11,
+        voteStart,
+        voteYear,
         rank: musicRank.value,
         query: getAdditionalConstraintString(additionalConstraint.value),
       }

--- a/packages/result/src/pages/QuestionnaireDetail.vue
+++ b/packages/result/src/pages/QuestionnaireDetail.vue
@@ -64,6 +64,7 @@
   </div>
 </template>
 <script lang="ts" setup>
+import { voteStart, voteYear } from '@/lib/voteYear'
 import { useRoute } from 'vue-router'
 import { gql, useQuery } from '@/composables/graphql'
 import type { Query } from '@/composables/graphql'
@@ -94,15 +95,15 @@ watch(additionalConstraint, () => {
     variables:
       getAdditionalConstraintString(additionalConstraint.value) === ''
         ? {
-            voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-            voteYear: 11,
+            voteStart,
+            voteYear,
             // Use the first question to present the trend
             questionIds: ['q11011'],
           }
         : {
             query: getAdditionalConstraintString(additionalConstraint.value),
-            voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-            voteYear: 11,
+            voteStart,
+            voteYear,
             // Use the first question to present the trend
             questionIds: ['q11011'],
           },
@@ -137,15 +138,15 @@ const { result, loading, onError, fetchMore } = useQuery<Query>(
   `,
   getAdditionalConstraintString(additionalConstraint.value) === ''
     ? {
-        voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-        voteYear: 11,
+        voteStart,
+        voteYear,
         // Use the first question to present the trend
         questionIds: ['q11011'],
       }
     : {
         query: getAdditionalConstraintString(additionalConstraint.value),
-        voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-        voteYear: 11,
+        voteStart,
+        voteYear,
         // Use the first question to present the trend
         questionIds: ['q11011'],
       }

--- a/packages/result/src/pages/QuestionnaireInputDetail.vue
+++ b/packages/result/src/pages/QuestionnaireInputDetail.vue
@@ -44,6 +44,7 @@
   </div>
 </template>
 <script lang="ts" setup>
+import { voteStart, voteYear } from '@/lib/voteYear'
 import { useRoute } from 'vue-router'
 import { gql, useQuery } from '@/composables/graphql'
 import type { Query } from '@/composables/graphql'
@@ -81,13 +82,13 @@ const { result, loading, onError } = useQuery<Query>(
   `,
   q.value === ''
     ? {
-        voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-        voteYear: 11,
+        voteStart,
+        voteYear,
         questionsOfInterest: [qid.value],
       }
     : {
-        voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-        voteYear: 11,
+        voteStart,
+        voteYear,
         query: q.value,
         questionsOfInterest: [qid.value],
       }

--- a/packages/result/src/pages/character.vue
+++ b/packages/result/src/pages/character.vue
@@ -43,6 +43,7 @@
 </template>
 
 <script lang="ts" setup>
+import { voteStart, voteYear } from '@/lib/voteYear'
 import { gql, useQuery } from '@/composables/graphql'
 import type { Query } from '@/composables/graphql'
 import NProgress from 'nprogress'
@@ -92,8 +93,8 @@ const {
   `,
 
   {
-    voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-    voteYear: 11,
+    voteStart,
+    voteYear,
   },
   {
     fetchPolicy: 'network-only',

--- a/packages/result/src/pages/characterCompare.vue
+++ b/packages/result/src/pages/characterCompare.vue
@@ -143,6 +143,7 @@
 </template>
 
 <script lang="ts" setup>
+import { voteStart, voteYear } from '@/lib/voteYear'
 import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 import { gql, useQuery } from '@/composables/graphql'
@@ -495,8 +496,8 @@ const {
     }
   `,
   {
-    voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-    voteYear: 11,
+    voteStart,
+    voteYear,
   },
   {
     fetchPolicy: 'network-only',

--- a/packages/result/src/pages/characterDetail.vue
+++ b/packages/result/src/pages/characterDetail.vue
@@ -146,6 +146,7 @@
 </template>
 
 <script lang="ts" setup>
+import { voteStart, voteYear } from '@/lib/voteYear'
 import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 import { gql, useQuery } from '@/composables/graphql'
@@ -363,13 +364,13 @@ watch(additionalConstraint, () => {
     variables:
       getAdditionalConstraintString(additionalConstraint.value) === ''
         ? {
-            voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-            voteYear: 11,
+            voteStart,
+            voteYear,
           }
         : {
             query: getAdditionalConstraintString(additionalConstraint.value),
-            voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-            voteYear: 11,
+            voteStart,
+            voteYear,
           },
     updateQuery(previousQueryResult, { fetchMoreResult }) {
       if (!fetchMoreResult) return previousQueryResult
@@ -385,13 +386,13 @@ watch(queryword, () => {
     variables:
       queryword.value === ''
         ? {
-            voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-            voteYear: 11,
+            voteStart,
+            voteYear,
           }
         : {
             query: queryword.value,
-            voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-            voteYear: 11,
+            voteStart,
+            voteYear,
           },
     updateQuery(previousQueryResult, { fetchMoreResult }) {
       if (!fetchMoreResult) return previousQueryResult
@@ -407,23 +408,23 @@ watch(GUIMode, () => {
     variables: GUIMode.value
       ? getAdditionalConstraintString(additionalConstraint.value) === ''
         ? {
-            voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-            voteYear: 11,
+            voteStart,
+            voteYear,
           }
         : {
             query: getAdditionalConstraintString(additionalConstraint.value),
-            voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-            voteYear: 11,
+            voteStart,
+            voteYear,
           }
       : queryword.value === ''
       ? {
-          voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-          voteYear: 11,
+          voteStart,
+          voteYear,
         }
       : {
           query: queryword.value,
-          voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-          voteYear: 11,
+          voteStart,
+          voteYear,
         },
     updateQuery(previousQueryResult, { fetchMoreResult }) {
       if (!fetchMoreResult) return previousQueryResult
@@ -484,23 +485,23 @@ const {
   GUIMode.value
     ? getAdditionalConstraintString(additionalConstraint.value) === ''
       ? {
-          voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-          voteYear: 11,
+          voteStart,
+          voteYear,
         }
       : {
           query: getAdditionalConstraintString(additionalConstraint.value),
-          voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-          voteYear: 11,
+          voteStart,
+          voteYear,
         }
     : queryword.value === ''
     ? {
-        voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-        voteYear: 11,
+        voteStart,
+        voteYear,
       }
     : {
         query: queryword.value,
-        voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-        voteYear: 11,
+        voteStart,
+        voteYear,
       },
   {
     fetchPolicy: 'network-only',

--- a/packages/result/src/pages/characterEvolution.vue
+++ b/packages/result/src/pages/characterEvolution.vue
@@ -78,7 +78,7 @@
         <div class="md:my-1 px-3 py-1 bg-white bg-opacity-80 rounded-b md:bg-opacity-0 text-sm italic text-gray-700">
           * 该图表表示该角色随着投票进程的票数变化情况<br />
           * 其中减少的票数是因为投票人修改自己的投票去掉该角色而导致<br />
-          * 投票时间：2022-06-17 18:00:00 至 2022-07-05 00:00:00
+          * 投票时间以当届公示为准
         </div>
         <div class="px-3 pt-3 md:pt-1 text-lg border-b border-accent-300">总票数演进</div>
         <!-- Graph for vote evolution -->
@@ -91,6 +91,7 @@
   </div>
 </template>
 <script lang="ts" setup>
+import { voteStart, voteYear } from '@/lib/voteYear'
 import { watchEffect } from 'vue'
 import NProgress from 'nprogress'
 import { gql, useLazyQuery, useQuery } from '@/composables/graphql'
@@ -154,15 +155,15 @@ async function getCharacterEvolution(): Promise<void> {
   trendCharacterNumber.value = charactersForEvolution.value.length
   if (queryCharacterEbvolutionForceDisabled.value)
     loadCharacterEbvolution(undefined, {
-      voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-      voteYear: 11,
+      voteStart,
+      voteYear,
       names: charactersForEvolution.value,
     })
   else
     queryCharacterEbvolutionMore({
       variables: {
-        voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-        voteYear: 11,
+        voteStart,
+        voteYear,
         names: charactersForEvolution.value,
       },
       updateQuery(previousQueryResult, { fetchMoreResult }) {
@@ -194,8 +195,8 @@ const {
     }
   `,
   {
-    voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-    voteYear: 11,
+    voteStart,
+    voteYear,
     names: charactersForEvolution.value,
   },
   {
@@ -251,8 +252,8 @@ const {
     }
   `,
   {
-    voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-    voteYear: 11,
+    voteStart,
+    voteYear,
   },
   {
     fetchPolicy: 'network-only',

--- a/packages/result/src/pages/characterSingleDetail.vue
+++ b/packages/result/src/pages/characterSingleDetail.vue
@@ -63,6 +63,7 @@
   </div>
 </template>
 <script lang="ts" setup>
+import { voteStart, voteYear } from '@/lib/voteYear'
 import { useRoute } from 'vue-router'
 import { gql, useQuery } from '@/composables/graphql'
 import type { Query } from '@/composables/graphql'
@@ -121,13 +122,13 @@ const { result, loading, onError } = useQuery<Query>(
   `,
   getAdditionalConstraintString(additionalConstraint.value) === ''
     ? {
-        voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-        voteYear: 11,
+        voteStart,
+        voteYear,
         rank: characterRank.value,
       }
     : {
-        voteStart: new Date(Date.UTC(2023, 11, 29, 10)),
-        voteYear: 11,
+        voteStart,
+        voteYear,
         rank: characterRank.value,
         query: getAdditionalConstraintString(additionalConstraint.value),
       }

--- a/packages/result/vite.config.ts
+++ b/packages/result/vite.config.ts
@@ -48,8 +48,12 @@ export default defineConfig({
   ],
   server: {
     proxy: {
+      // 对应 Dockerfile.result.template 的 `location /res-be/` → 后端根路径。
+      // 源码只用 /res-be/graphql（composables/graphql/index.ts）。
+      // 此前指向老 Rust 生产后端 touhou.ai，而 result 页面已按 Python 契约层
+      // 重写（12 个 query* 字段），老 Rust 没有这些字段 → dev 下必然报错。
       '/res-be': {
-        target: 'https://touhou.ai/vote-be',
+        target: process.env.VITE_DEV_BACKEND ?? 'http://154.37.215.62:18000',
         changeOrigin: true,
         secure: false,
         rewrite: (path) => path.replace(/^\/res-be/, ''),

--- a/packages/shared/composables/setSiteTitle.ts
+++ b/packages/shared/composables/setSiteTitle.ts
@@ -1,3 +1,5 @@
+import { voteYear } from '../data/voteYear'
+
 export function setSiteTitle(title = ''): void {
-  document.title = title + (title && ' - ') + '第11回 中文东方人气投票'
+  document.title = title + (title && ' - ') + `第${voteYear}回 中文东方人气投票`
 }

--- a/packages/shared/data/questionnaire.ts
+++ b/packages/shared/data/questionnaire.ts
@@ -265,7 +265,7 @@ export const questionnaire: QuestionnaireALL = {
             introduction: '',
             input: '',
             options: [
-              { id: 11109101, related: [], mutex: [], content: '1', group: 0 },
+              { id: 1109101, related: [], mutex: [], content: '1', group: 0 },
               { id: 1109102, related: [], mutex: [], content: '2', group: 0 },
               { id: 1109103, related: [], mutex: [], content: '3', group: 0 },
               { id: 1109104, related: [], mutex: [], content: '4', group: 0 },

--- a/packages/shared/data/voteYear.ts
+++ b/packages/shared/data/voteYear.ts
@@ -1,1 +1,7 @@
 export const voteYear = 12
+
+// 本届投票开始时刻——结果站趋势图把后端返回的"小时桶"换算成日历时间的轴起点。
+// ⚠️ 必须与后端 Nacos 配置 `VOTE_START_ISO` 保持一致(后端按同一起点分桶),
+// 改任何一边都要同步另一边。当前值为测试环境占位窗口(2026-01-01T00:00:00Z),
+// 本届正式定档后更新此处 + Nacos 两处。
+export const voteStart = new Date(Date.UTC(2026, 0, 1, 0))

--- a/packages/vote/index.html
+++ b/packages/vote/index.html
@@ -4,7 +4,8 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>第11回 中文东方人气投票</title>
+    <!-- 静态标题不带届数(防跨届过期);运行时由 setSiteTitle 按 shared voteYear 覆盖 -->
+    <title>中文东方人气投票</title>
     <meta name="referrer" content="same-origin" />
   </head>
   <body>

--- a/packages/vote/src/common/components/VoteCheckBox.vue
+++ b/packages/vote/src/common/components/VoteCheckBox.vue
@@ -1,8 +1,7 @@
 <template>
   <div class="inline-block align-middle">
     <input
-      id="checkBox"
-      read-only="true"
+      :id="uid"
       :checked="check"
       class="hidden checked:label:bg-accent-color-600"
       type="checkbox"
@@ -10,7 +9,7 @@
       @change="changeCheck()"
     />
     <label
-      for="checkBox"
+      :for="uid"
       class="inline-block w-5 h-5 rounded border border-accent-color-300 relative cursor-pointer before:inline-block before:w-4.5 before:h-1.5 before:border before:border-3 before:borde-white before:border-t-0 before:border-r-0 before:transform before:transform-gpu before:-rotate-45 before:top-1 before:left-0 before:absolute before:opacity-0"
     ></label>
   </div>
@@ -18,6 +17,9 @@
 
 <script lang="ts" setup>
 import { useVModel } from '@vueuse/core'
+
+let uidCounter = 0
+const uid = `vote-checkbox-${++uidCounter}`
 
 const props = defineProps({
   readOnly: {

--- a/packages/vote/src/common/components/VoteSelect.vue
+++ b/packages/vote/src/common/components/VoteSelect.vue
@@ -48,7 +48,7 @@ const props = defineProps({
   itemList: {
     type: Array as PropType<SelectList[]>,
     default: () => [],
-    requred: true,
+    required: true,
   },
   selected: {
     type: Object as PropType<SelectList>,
@@ -58,7 +58,7 @@ const props = defineProps({
         value: '',
       }
     },
-    requred: true,
+    required: true,
   },
   selectedName: {
     type: String,

--- a/packages/vote/src/common/lib/voteObjectsDataSource.ts
+++ b/packages/vote/src/common/lib/voteObjectsDataSource.ts
@@ -15,21 +15,21 @@ interface FilterMeta {
 }
 
 interface BackendCharacterItem {
-  id: number
+  candidateId: number
   name: string
-  name_jp: string
+  nameJp: string
   workIds: number[]
   workTypes: string[]
-  first_appearance: string | null
+  firstAppearance: string | null
 }
 
 interface BackendMusicItem {
-  id: number
+  candidateId: number
   name: string
-  name_jp: string
+  nameJp: string
   workIds: number[]
   workTypes: string[]
-  first_appearance: string | null
+  firstAppearance: string | null
 }
 
 interface BackendGroup<T> {
@@ -71,9 +71,9 @@ function enrichCharacter(item: BackendCharacterItem): Character {
     ? (item.workTypes.filter(Boolean) as ('old' | 'new' | 'book' | 'CD' | 'others')[])
     : (s?.kind?.length ? s.kind : ['others'])
   return new Character(
-    String(item.id),
+    String(item.candidateId),
     item.name,
-    s?.origname ?? item.name_jp,
+    s?.origname ?? item.nameJp,
     s?.altnames ?? [],
     s?.title ?? '',
     s?.image ?? 'https://static.thwiki.cc/favicon.png',
@@ -94,9 +94,9 @@ function enrichMusic(item: BackendMusicItem): Music {
     ? (item.workTypes.filter(Boolean) as ('game' | 'book' | 'CD' | 'others')[])
     : (s?.kind?.length ? s.kind : ['others'])
   return new Music(
-    String(item.id),
+    String(item.candidateId),
     item.name,
-    s?.origname ?? item.name_jp,
+    s?.origname ?? item.nameJp,
     albumName, // album → work name
     s?.date ?? 0,
     s?.image ?? 'https://static.thwiki.cc/favicon.png',

--- a/packages/vote/src/darkmode/index.ts
+++ b/packages/vote/src/darkmode/index.ts
@@ -17,6 +17,8 @@ function updateDOM(v: boolean) {
   }
 }
 
+const preferredDark = usePreferredDark()
+
 export const isDark = ref(false)
 
 watch(
@@ -25,7 +27,7 @@ watch(
     if (themes.includes(themePreference.value)) {
       isDark.value = themePreference.value === 'dark'
     } else {
-      isDark.value = usePreferredDark().value
+      isDark.value = preferredDark.value
     }
   },
   {
@@ -37,9 +39,9 @@ watch(
 watch(
   [isDark],
   () => {
-    if (themes.includes(themePreference.value) && isDark.value === usePreferredDark().value) {
+    if (themes.includes(themePreference.value) && isDark.value === preferredDark.value) {
       themePreference.value = ''
-    } else if (isDark.value !== usePreferredDark().value) {
+    } else if (isDark.value !== preferredDark.value) {
       themePreference.value = isDark.value ? 'dark' : 'light'
     }
     updateDOM(isDark.value)

--- a/packages/vote/src/home/UserSettings.vue
+++ b/packages/vote/src/home/UserSettings.vue
@@ -229,7 +229,7 @@ updateUsernameDone((result) => {
 updateUsernameError((error) => {
   console.log(error.graphQLErrors?.[0]?.extensions?.error_kind)
   if (error.graphQLErrors?.[0]?.extensions?.error_kind === 'REQUEST_TOO_FREQUENT') popMessageText('请求过于频繁！')
-  else popMessageText('投票失败，原因：' + error.graphQLErrors?.[0]?.extensions?.human_readable_message)
+  else popMessageText('修改用户名失败，原因：' + error.graphQLErrors?.[0]?.extensions?.human_readable_message)
   updateUsernameOpen.value = false
 })
 
@@ -279,7 +279,7 @@ updatePasswordDone((result) => {
 updatePasswordError((error) => {
   console.log(error.graphQLErrors?.[0]?.extensions?.error_kind)
   if (error.graphQLErrors?.[0]?.extensions?.error_kind === 'REQUEST_TOO_FREQUENT') popMessageText('请求过于频繁！')
-  else popMessageText('投票失败，原因：' + error.graphQLErrors?.[0]?.extensions?.human_readable_message)
+  else popMessageText('修改密码失败，原因：' + error.graphQLErrors?.[0]?.extensions?.human_readable_message)
   changePasswordOpen.value = false
 })
 

--- a/packages/vote/src/home/components/LoginBox.vue
+++ b/packages/vote/src/home/components/LoginBox.vue
@@ -136,7 +136,7 @@
   <Mask v-model:open="open" />
 </template>
 <script lang="ts" setup>
-import { computed, ref, shallowRef, watchEffect } from 'vue'
+import { computed, onUnmounted, ref, shallowRef, watchEffect } from 'vue'
 import { useVModel } from '@vueuse/core'
 import { gql, useMutation } from '@/graphql'
 import type { Mutation } from '@/graphql'
@@ -150,7 +150,7 @@ const props = defineProps({
   open: {
     type: Boolean,
     default: false,
-    requred: true,
+    required: true,
   },
 })
 const emit = defineEmits<{
@@ -161,6 +161,10 @@ const open = useVModel(props, 'open', emit)
 watchEffect(() => {
   if (!open.value) document.getElementsByTagName('body')[0].setAttribute('style', 'overflow:auto')
   else document.getElementsByTagName('body')[0].setAttribute('style', 'overflow:hidden')
+})
+onUnmounted(() => {
+  document.getElementsByTagName('body')[0].setAttribute('style', 'overflow:auto')
+  if (verificationCodeAvailableTimer) clearInterval(verificationCodeAvailableTimer)
 })
 function close(): void {
   open.value = false

--- a/packages/vote/src/home/components/UserVoteDp.vue
+++ b/packages/vote/src/home/components/UserVoteDp.vue
@@ -13,7 +13,7 @@
       >
         <img class="w-32 h-32 object-cover" :src="vote.image" />
         <div>
-          <CompleteTag :complete="vote.compelete.value" />
+          <CompleteTag :complete="vote.complete.value" />
           <h3 class="text-2xl max-w-17ch" v-text="vote.name"></h3>
           <span v-text="vote.desc"></span>
         </div>
@@ -34,19 +34,19 @@ const votes = {
     name: '角色部门',
     desc: '为喜欢的角色投票',
     image: 'https://asset.lilywhite.cc/thvote/imgs/nav/character@100px.png',
-    compelete: voteCharacterComplete,
+    complete: voteCharacterComplete,
   },
   music: {
     name: '音乐部门',
     desc: '为喜欢的音乐投票',
     image: 'https://asset.lilywhite.cc/thvote/imgs/nav/music@100px.png',
-    compelete: voteMusicComplete,
+    complete: voteMusicComplete,
   },
   couple: {
     name: 'CP部门',
     desc: '为喜欢的角色组合投票',
     image: 'https://asset.lilywhite.cc/thvote/imgs/nav/couple@100px.png',
-    compelete: voteCoupleComplete,
+    complete: voteCoupleComplete,
   },
 }
 </script>

--- a/packages/vote/src/home/lib/user.ts
+++ b/packages/vote/src/home/lib/user.ts
@@ -2,7 +2,6 @@ import { computed, ref } from 'vue'
 import type { Voter } from '@/graphql/__generated__/graphql'
 import { clearQuestionnaireV2LocalData, restorePaperV2 } from '@/questionnaire/lib/questionnaireStateV2'
 import { API_PREFIX } from '@/common/lib/apiPrefix'
-import { popMessageText } from '@/common/lib/popMessage'
 
 export function createDefaultVoter(): Voter {
   return {
@@ -182,10 +181,7 @@ export async function checkLoginStatus(needGetUserDataFromLocalStorage = false):
       }
     })
     .catch((err) => {
-      console.log(err)
-      if (err.graphQLErrors && err.graphQLErrors?.[0]?.extensions?.error_kind === 'REQUEST_TOO_FREQUENT') {
-        popMessageText('请求过于频繁！')
-      }
+      console.error('[checkLoginStatus]', err)
       deleteUserData()
     })
 }

--- a/packages/vote/src/main/main.ts
+++ b/packages/vote/src/main/main.ts
@@ -56,7 +56,7 @@ appPromises.push(loadVoteObjects())
 // router config
 declare module 'vue-router' {
   interface RouteMeta {
-    requriequestionnaire?: boolean
+    requireQuestionnaire?: boolean
     availableAfterVoteEnded?: boolean
   }
 }
@@ -81,22 +81,22 @@ const router = createRouter({
     {
       path: '/vote/character',
       component: () => import('@/vote-character/VoteCharacter.vue'),
-      meta: { requriequestionnaire: true },
+      meta: { requireQuestionnaire: true },
     },
     {
       path: '/vote/music',
       component: () => import('@/vote-music/VoteMusic.vue'),
-      meta: { requriequestionnaire: true },
+      meta: { requireQuestionnaire: true },
     },
     {
       path: '/vote/couple',
       component: () => import('@/vote-couple/VoteCouple.vue'),
-      meta: { requriequestionnaire: true },
+      meta: { requireQuestionnaire: true },
     },
     {
       path: '/doujin',
       component: () => import('@/vote-doujin/VoteDoujin.vue'),
-      meta: { requriequestionnaire: true },
+      meta: { requireQuestionnaire: true },
     },
     {
       path: '/test',
@@ -118,7 +118,7 @@ router.beforeEach(async (to, from, next) => {
   else if (to.path != '/' && !isLogin.value) next({ path: '/' })
   else if (to.meta.availableAfterVoteEnded && voteEnded()) next()
   else if (voteEnded()) next({ path: '/' })
-  else if (to.meta.requriequestionnaire && !structureError.value && !isQuestionnaireAllDoneV2.value)
+  else if (to.meta.requireQuestionnaire && !structureError.value && !isQuestionnaireAllDoneV2.value)
     next({ path: '/' })
   else next()
 })

--- a/packages/vote/src/questionnaire/Questionnaire.vue
+++ b/packages/vote/src/questionnaire/Questionnaire.vue
@@ -157,9 +157,7 @@ import { gql, useMutation } from '@/graphql'
 import { voteToken } from '@/home/lib/user'
 import { screenSizes } from '@/tailwindcss'
 import { popConfirmText, popMessageText } from '@/common/lib/popMessage'
-import { getDeviceId } from '@/common/lib/deviceId'
-import { readFillDuration, startFillTimer } from '@/common/lib/fillTimer'
-import { getClientEnv } from '@/common/lib/clientEnv'
+import { startFillTimer } from '@/common/lib/fillTimer'
 startFillTimer('paper')
 
 setSiteTitle('调查问卷')
@@ -253,13 +251,8 @@ async function submitQuestionnire(): Promise<void> {
   }
   if (await popConfirmText('确认提交' + questionnaireName.value + '吗？（您之后还可以修改）')) {
     mutate({
-      content: {
-        voteToken: voteToken.value,
-        paperJson: JSON.stringify(questionnaireData.value),
-        deviceId: getDeviceId(),
-        fillDurationMs: readFillDuration('paper'),
-        clientEnv: getClientEnv(),
-      },
+      voteToken: voteToken.value,
+      answers: payload,
     })
   }
 }

--- a/packages/vote/src/questionnaire/components/QuestionnaireChange.vue
+++ b/packages/vote/src/questionnaire/components/QuestionnaireChange.vue
@@ -51,7 +51,7 @@
 </template>
 
 <script lang="ts" setup>
-import { onMounted, ref, watch, watchEffect } from 'vue'
+import { onMounted, onUnmounted, ref, watch, watchEffect } from 'vue'
 import { useVModel } from '@vueuse/core'
 import { useRoute, useRouter } from 'vue-router'
 import { getRuntime, questionnaireKeyToNameV2 } from '@/questionnaire/lib/questionnaireStateV2'
@@ -65,16 +65,16 @@ const props = defineProps({
   open: {
     type: Boolean,
     default: false,
-    requred: true,
+    required: true,
   },
   questionnaireId: {
     type: Number,
     default: 0,
-    requred: true,
+    required: true,
   },
 })
 const emit = defineEmits<{
-  (event: 'update:open', value: string): void
+  (event: 'update:open', value: boolean): void
   (event: 'changeQuestion', direction: 'forward' | 'back' | 'no'): void
 }>()
 
@@ -120,10 +120,15 @@ function unfoldAllQuestionnaire() {
   })
 }
 onMounted(() => screenSizes['<2xl'] && selectAsQuestionnaireCurrent(selectedQuestionnaire.value))
-window.onresize = () => {
+const handleResize = () => {
   // 1536px: 2xl, screenSizes['<2xl'] does not respond timely
   window.innerWidth < 1536 ? selectAsQuestionnaireCurrent(selectedQuestionnaire.value) : unfoldAllQuestionnaire()
 }
+window.addEventListener('resize', handleResize)
+onUnmounted(() => {
+  document.getElementsByTagName('body')[0].setAttribute('style', 'overflow:auto')
+  window.removeEventListener('resize', handleResize)
+})
 
 function changeQuestion(questionnaireId: number, index: number): void {
   emit('changeQuestion', 'no')

--- a/packages/vote/src/vote-character/VoteCharacter.vue
+++ b/packages/vote/src/vote-character/VoteCharacter.vue
@@ -43,7 +43,7 @@
       </transition>
 
       <div class="baseBoxRoundedShadow p-1 w-full">
-        <div class="p-1 flex justify-between md:text-base xl:text-xl 2xl:text-2xl®">
+        <div class="p-1 flex justify-between md:text-base xl:text-xl 2xl:text-2xl">
           <div>
             {{
               '我喜欢的角色(' +

--- a/packages/vote/src/vote-character/components/AdvancedFilter.vue
+++ b/packages/vote/src/vote-character/components/AdvancedFilter.vue
@@ -63,7 +63,7 @@ import Mask from '@/common/components/Mask.vue'
 const props = defineProps({
   open: {
     type: Boolean,
-    requred: true,
+    required: true,
   },
 })
 const emit = defineEmits<{
@@ -74,7 +74,7 @@ function close(): void {
   open.value = false
 }
 
-watch(filterForKindTem.value, resetWorkSelectedTem)
+watch(filterForKindTem, resetWorkSelectedTem)
 
 function cancelFilter(): void {
   getFilterForKindTem()

--- a/packages/vote/src/vote-character/components/CharacterCard.vue
+++ b/packages/vote/src/vote-character/components/CharacterCard.vue
@@ -39,7 +39,7 @@ import characterImages from '@/vote-character/assets/defaultCharacterImage.png?u
 const props = defineProps({
   character: {
     type: Object as PropType<Character>,
-    requred: true,
+    required: true,
     default: function () {
       return new Character()
     },

--- a/packages/vote/src/vote-character/components/CharacterHonmeiCard.vue
+++ b/packages/vote/src/vote-character/components/CharacterHonmeiCard.vue
@@ -44,7 +44,7 @@ const props = defineProps({
   // Note that characterHonmei in voteData.ts is readonly
   characterHonmei: {
     type: Object as PropType<Character>,
-    requred: true,
+    required: true,
     default: function () {
       return new Character()
     },

--- a/packages/vote/src/vote-character/components/CharacterSelect.vue
+++ b/packages/vote/src/vote-character/components/CharacterSelect.vue
@@ -80,16 +80,16 @@ import Mask from '@/common/components/Mask.vue'
 const props = defineProps({
   open: {
     type: Boolean,
-    requred: true,
+    required: true,
   },
   characterHonmeiIsSelected: {
     type: Boolean,
-    requred: true,
+    required: true,
     default: true,
   },
   characterSelected: {
     type: Object as PropType<Character>,
-    requred: true,
+    required: true,
     default: function () {
       return new Character()
     },

--- a/packages/vote/src/vote-character/lib/characterList.ts
+++ b/packages/vote/src/vote-character/lib/characterList.ts
@@ -3,7 +3,7 @@ import type { Character } from './character'
 import { character0 } from './character'
 import { characterHonmei, characters } from './voteData'
 import { filterForKind, workSelected } from './workList'
-import { characterListFromBackend } from '@/common/lib/voteObjectsDataSource'
+import { characterListFromBackend, characterGroupsRaw } from '@/common/lib/voteObjectsDataSource'
 import { orderOptions as sharedOrderOptions, filterCharactersByMeta, searchAndSort } from '@/common/lib/characterSearch'
 
 export const characterList = characterListFromBackend
@@ -20,6 +20,17 @@ export const characterListLeft = computed<Character[]>(() => {
   const kinds = filterForKind.value.map((k) => k.value)
   charaList = filterCharactersByMeta(charaList, kinds, workSelected.value.name || undefined)
 
+  if (!charaList.length) {
+    console.warn('[DEBUG characterListLeft] EMPTY!', {
+      totalChars: characterList.value.length,
+      groupsRawLen: characterGroupsRaw.value.length,
+      votedIds: characters.value.map(c => c.id),
+      honmeiId: characterHonmei.value.id,
+      filterForKindN: filterForKind.value.length,
+      kinds,
+      workSelected: workSelected.value.name,
+    })
+  }
 
   return charaList
 })

--- a/packages/vote/src/vote-couple/components/AdvancedFilter.vue
+++ b/packages/vote/src/vote-couple/components/AdvancedFilter.vue
@@ -63,7 +63,7 @@ import Mask from '@/common/components/Mask.vue'
 const props = defineProps({
   open: {
     type: Boolean,
-    requred: true,
+    required: true,
   },
 })
 const emit = defineEmits<{
@@ -74,7 +74,7 @@ function close(): void {
   open.value = false
 }
 
-watch(filterForKindTem.value, resetWorkSelectedTem)
+watch(filterForKindTem, resetWorkSelectedTem)
 
 function cancelFilter(): void {
   getFilterForKindTem()

--- a/packages/vote/src/vote-couple/components/CharacterSelect.vue
+++ b/packages/vote/src/vote-couple/components/CharacterSelect.vue
@@ -68,18 +68,18 @@ import Mask from '@/common/components/Mask.vue'
 const props = defineProps({
   open: {
     type: Boolean,
-    requred: true,
+    required: true,
   },
   coupleSelected: {
     type: Object as PropType<Couple>,
-    requred: true,
+    required: true,
     default: function () {
       return new Couple()
     },
   },
   characterSelected: {
     type: Object as PropType<Character>,
-    requred: true,
+    required: true,
     default: function () {
       return new Character()
     },
@@ -87,7 +87,7 @@ const props = defineProps({
   // flag is used to judge whether user selected same character or just close the window
   flag: {
     type: Number,
-    requred: true,
+    required: true,
     default: 0,
   },
 })

--- a/packages/vote/src/vote-couple/components/CoupleCard.vue
+++ b/packages/vote/src/vote-couple/components/CoupleCard.vue
@@ -79,7 +79,7 @@ const props = defineProps({
   },
   couple: {
     type: Object as PropType<Couple>,
-    requred: true,
+    required: true,
     default: function () {
       return new Couple()
     },

--- a/packages/vote/src/vote-doujin/components/DoujinCard.vue
+++ b/packages/vote/src/vote-doujin/components/DoujinCard.vue
@@ -47,7 +47,7 @@ import { Doujin, Doujin0, Doujin0NoImageUrl, getDoujinTypeData } from '@/vote-do
 const props = defineProps({
   doujin: {
     type: Object as PropType<Doujin>,
-    requred: true,
+    required: true,
     default: function () {
       return new Doujin()
     },

--- a/packages/vote/src/vote-doujin/components/DoujinCardDp.vue
+++ b/packages/vote/src/vote-doujin/components/DoujinCardDp.vue
@@ -49,7 +49,7 @@ import { Doujin, Doujin0, Doujin0NoImageUrl, getDoujinTypeData } from '@/vote-do
 const props = defineProps({
   doujin: {
     type: Object as PropType<Doujin>,
-    requred: true,
+    required: true,
     default: function () {
       return new Doujin()
     },

--- a/packages/vote/src/vote-doujin/components/EditDoujin.vue
+++ b/packages/vote/src/vote-doujin/components/EditDoujin.vue
@@ -144,7 +144,7 @@
             删除
           </button>
           <button class="px-5 py-1 bg-white text-accent-color-300 border" @click="cancelEdit()">取消</button>
-          <button class="px-5 py-1" @click="comfirmEdit()">确定</button>
+          <button class="px-5 py-1" @click="confirmEdit()">确定</button>
         </div>
       </div>
       <Transition name="mask">
@@ -217,7 +217,7 @@ import { API_PREFIX } from '@/common/lib/apiPrefix'
 const props = defineProps({
   open: {
     type: Boolean,
-    requred: true,
+    required: true,
   },
   index: {
     type: Number,
@@ -225,7 +225,7 @@ const props = defineProps({
   },
 })
 const emit = defineEmits<{
-  (event: 'update:open', value: Doujin): void
+  (event: 'update:open', value: boolean): void
 }>()
 const open = useVModel(props, 'open', emit)
 
@@ -338,7 +338,7 @@ async function fetchMsg(): Promise<void> {
 // 夕渃 2023/12/25 20:15
 // @Lurantis 其实你可以不用我搞了正则你还搞，你只要确保丢到我这边的是一个合法的url就行了
 const universalSiteRegExp = new RegExp(
-  '^((http|https):\/\/)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$'
+  '^((http|https):\\/\\/)?[a-z0-9]+([\\-\\.]{1}[a-z0-9]+)*\\.[a-z]{2,5}(:[0-9]{1,5})?(\\/.*)?$'
 )
 // const bilibiliRegExp = new RegExp(
 //   '^(https:\\/\\/|http:\\/\\/)?(www\\.|m\\.)?(bilibili\\.com\\/video\\/([aA][vV][\\d]+|BV[a-zA-Z0-9]+)(\\?p=[\\d]+)?|b23\\.tv\\/([aA][vV][\\d]+|BV[a-zA-Z0-9]+)(\\?p=[\\d]+)?|b23\\.tv\\/[\\w\\d]+)'
@@ -472,7 +472,7 @@ async function cancelEdit(): Promise<void> {
     close()
   }
 }
-function comfirmEdit(): void {
+function confirmEdit(): void {
   if (isDoujinValid.value) {
     submitDoujinData()
     close()

--- a/packages/vote/src/vote-doujin/components/VoteDoujinDp.vue
+++ b/packages/vote/src/vote-doujin/components/VoteDoujinDp.vue
@@ -83,9 +83,13 @@ import { popMessageText } from '@/common/lib/popMessage'
 import { getDeviceId } from '@/common/lib/deviceId'
 import { readFillDuration, startFillTimer } from '@/common/lib/fillTimer'
 import { getClientEnv } from '@/common/lib/clientEnv'
+import { handleQuestionnaireGateError } from '@/common/lib/voteGateError'
+import { useRouter } from 'vue-router'
 startFillTimer('doujin')
 
 setSiteTitle('提名作品')
+
+const router = useRouter()
 
 const confirmedNotice = useLocalStorage('confirmedDoujinNotice', false)
 
@@ -165,6 +169,7 @@ onDone((result) => {
   confirmedNotice.value = false
 })
 onError((error) => {
+  if (handleQuestionnaireGateError(error, router)) return
   console.log(error.graphQLErrors?.[0]?.extensions?.error_kind)
   if (error.graphQLErrors?.[0]?.extensions?.error_kind === 'REQUEST_TOO_FREQUENT') popMessageText('请求过于频繁！')
   else popMessageText('投票失败，原因：' + error.graphQLErrors?.[0]?.extensions?.human_readable_message)

--- a/packages/vote/src/vote-music/VoteMusic.vue
+++ b/packages/vote/src/vote-music/VoteMusic.vue
@@ -43,7 +43,7 @@
       </transition>
 
       <div class="baseBoxRoundedShadow p-1 w-full">
-        <div class="p-1 flex justify-between md:text-base xl:text-xl 2xl:text-2xl®">
+        <div class="p-1 flex justify-between md:text-base xl:text-xl 2xl:text-2xl">
           <div>
             {{
               '我喜欢的曲目(' +

--- a/packages/vote/src/vote-music/components/AdvancedFilter.vue
+++ b/packages/vote/src/vote-music/components/AdvancedFilter.vue
@@ -63,7 +63,7 @@ import Mask from '@/common/components/Mask.vue'
 const props = defineProps({
   open: {
     type: Boolean,
-    requred: true,
+    required: true,
   },
 })
 const emit = defineEmits<{
@@ -74,7 +74,7 @@ function close(): void {
   open.value = false
 }
 
-watch(filterForKindTem.value, resetAlbumSelectedTem)
+watch(filterForKindTem, resetAlbumSelectedTem)
 
 function cancelFilter(): void {
   getFilterForKindTem()

--- a/packages/vote/src/vote-music/components/MusicCard.vue
+++ b/packages/vote/src/vote-music/components/MusicCard.vue
@@ -37,7 +37,7 @@ import MusicImages from '@/vote-music/assets/defaultMusicImage.jpg?url'
 const props = defineProps({
   music: {
     type: Object as PropType<Music>,
-    requred: true,
+    required: true,
     default: function () {
       return new Music()
     },

--- a/packages/vote/src/vote-music/components/MusicHonmeiCard.vue
+++ b/packages/vote/src/vote-music/components/MusicHonmeiCard.vue
@@ -44,7 +44,7 @@ const props = defineProps({
   // Note that characterHonmei in voteData.ts is readonly
   musicHonmei: {
     type: Object as PropType<Music>,
-    requred: true,
+    required: true,
     default: function () {
       return new Music()
     },
@@ -53,7 +53,7 @@ const props = defineProps({
 
 const reasonInput = shallowRef<HTMLInputElement | null>(null)
 const reasonEdit = ref(props.musicHonmei.reason)
-watch(props.musicHonmei, function (newv) {
+watch(() => props.musicHonmei, (newv) => {
   reasonEdit.value = newv.reason
 })
 function updateReason(): void {

--- a/packages/vote/src/vote-music/components/MusicSelect.vue
+++ b/packages/vote/src/vote-music/components/MusicSelect.vue
@@ -105,16 +105,16 @@ import MusicImages from '@/vote-music/assets/defaultMusicImage.jpg?url'
 const props = defineProps({
   open: {
     type: Boolean,
-    requred: true,
+    required: true,
   },
   musicHonmeiIsSelected: {
     type: Boolean,
-    requred: true,
+    required: true,
     default: true,
   },
   musicSelected: {
     type: Object as PropType<Music>,
-    requred: true,
+    required: true,
     default: function () {
       return new Music()
     },

--- a/packages/vote/vite.config.ts
+++ b/packages/vote/vite.config.ts
@@ -24,7 +24,11 @@ for (const dir of list) {
   }
 }
 
-const HOST = 'http://localhost'
+/**
+ * dev 模式下后端地址。默认指向测试机；想连本地起的后端时：
+ *   VITE_DEV_BACKEND=http://localhost:8000 pnpm dev
+ */
+const BACKEND = process.env.VITE_DEV_BACKEND ?? 'http://154.37.215.62:18000'
 
 export default defineConfig(({ command }) => {
   return {
@@ -62,20 +66,39 @@ export default defineConfig(({ command }) => {
     server: {
       port: 5175,
       proxy: {
-        // GraphQL 接口现在直接落在 /vote-be/graphql
-        '/v11-be/graphql': {
-          target: `${HOST}/vote-be/graphql`,
+        // ⚠️ 以下四条必须与 Dockerfile.vote.template 的 nginx v12 块**逐条对应**。
+        //    改一处必须同步另一处：dev 走这里、部署走 nginx，两边不一致会出现
+        //    "本地好的、线上坏的"（或反之）。2026-08-31 就是因为 v12 迁移只改了
+        //    apiPrefix.ts 和 nginx、漏了这里，导致 dev 下所有后端请求被 SPA
+        //    fallback 静默返回 index.html。
+        '/v12-be/vote-objects/': {
+          target: BACKEND,
           changeOrigin: true,
           secure: false,
-          rewrite: (path: string) => path.replace(/^\/v11-be\/graphql/, ''),
+          rewrite: (path: string) => path.replace(/^\/v12-be\/vote-objects\//, '/api/v1/vote-objects/'),
         },
 
-        // 其他后端接口仍然走 /v11-be 基路径
-        '/v11-be': {
-          target: `${HOST}/vote-be`,
+        '/v12-be/questionnaire/': {
+          target: BACKEND,
           changeOrigin: true,
           secure: false,
-          rewrite: (path: string) => path.replace(/^\/v11-be/, ''),
+          rewrite: (path: string) => path.replace(/^\/v12-be\/questionnaire\//, '/api/v1/questionnaire/'),
+        },
+
+        // 对应 nginx 的 `location = /v12-be/doujin/api`（精确匹配）
+        '^/v12-be/doujin/api(\\?.*)?$': {
+          target: BACKEND,
+          changeOrigin: true,
+          secure: false,
+          rewrite: (path: string) => path.replace(/^\/v12-be\/doujin\/api/, '/api/v1/scraper/scrape'),
+        },
+
+        // 兜底：覆盖 /graphql 与根路径的 legacy-compat 端点（如 /user-token-status）
+        '/v12-be/': {
+          target: BACKEND,
+          changeOrigin: true,
+          secure: false,
+          rewrite: (path: string) => path.replace(/^\/v12-be/, ''),
         },
         
         // 重点：解决东方云盘图片跨域的代理

--- a/questionnaire-placeholder.json
+++ b/questionnaire-placeholder.json
@@ -1,0 +1,878 @@
+{
+  "mainQuestionnaire": {
+    "requiredQuestionnaire": {
+      "id": 11,
+      "name": "主要问卷 - 基础问卷",
+      "introduction": "新版问卷结构占位数据。",
+      "questionGroups": [
+        {
+          "id": 1101,
+          "questionnaireId": 11,
+          "order": 1,
+          "initialQuestionId": 11011,
+          "questions": [
+            {
+              "id": 11011,
+              "type": "Single",
+              "content": "占位问题组 1：请选择你要进入的后续路径",
+              "introduction": "第一个问题组必须仅有一个问题，后续合作者可在此基础上替换为正式题面。",
+              "options": [
+                {
+                  "id": 1101101,
+                  "content": "进入问题组 2 的第 1 个问题",
+                  "relatedQuestionIds": [
+                    11021
+                  ],
+                  "mutexOptionIds": [],
+                  "optionGroup": 0
+                },
+                {
+                  "id": 1101102,
+                  "content": "进入问题组 2 的第 2 个问题",
+                  "relatedQuestionIds": [
+                    11022
+                  ],
+                  "mutexOptionIds": [],
+                  "optionGroup": 0
+                },
+                {
+                  "id": 1101103,
+                  "content": "隐藏问题组 2",
+                  "relatedQuestionIds": [
+                    11020
+                  ],
+                  "mutexOptionIds": [],
+                  "optionGroup": 0
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": 1102,
+          "questionnaireId": 11,
+          "order": 2,
+          "initialQuestionId": 11020,
+          "questions": [
+            {
+              "id": 11020,
+              "type": "Input",
+              "content": "占位问题组 2 - 第 0 个问题",
+              "introduction": "末位为 0，该问题组默认隐藏。不应在页面上直接展示。",
+              "options": []
+            },
+            {
+              "id": 11021,
+              "type": "Single",
+              "content": "占位问题组 2 - 第 1 个问题",
+              "introduction": "当 related 指向本题时，页面应展示本问题。",
+              "options": [
+                {
+                  "id": 1102101,
+                  "content": "继续",
+                  "relatedQuestionIds": [],
+                  "mutexOptionIds": [],
+                  "optionGroup": 0
+                },
+                {
+                  "id": 1102102,
+                  "content": "继续（备用）",
+                  "relatedQuestionIds": [],
+                  "mutexOptionIds": [],
+                  "optionGroup": 0
+                }
+              ]
+            },
+            {
+              "id": 11022,
+              "type": "Input",
+              "content": "占位问题组 2 - 第 2 个问题",
+              "introduction": "当 related 指向本题时，页面应展示本问题。",
+              "options": []
+            }
+          ]
+        },
+        {
+          "id": 1103,
+          "questionnaireId": 11,
+          "order": 3,
+          "initialQuestionId": 11031,
+          "questions": [
+            {
+              "id": 11031,
+              "type": "Input",
+              "content": "占位问题组 3 - 第 1 个问题",
+              "introduction": "本问题组初始问题不是第 0 个问题，因此默认展示第 1 个问题。",
+              "options": []
+            }
+          ]
+        }
+      ]
+    },
+    "optionalQuestionnaire1": {
+      "id": 12,
+      "name": "主要问卷 - 官作问卷",
+      "introduction": "新版问卷结构占位数据。",
+      "questionGroups": [
+        {
+          "id": 1201,
+          "questionnaireId": 12,
+          "order": 1,
+          "initialQuestionId": 12011,
+          "questions": [
+            {
+              "id": 12011,
+              "type": "Single",
+              "content": "占位问题组 1：请选择你要进入的后续路径",
+              "introduction": "第一个问题组必须仅有一个问题，后续合作者可在此基础上替换为正式题面。",
+              "options": [
+                {
+                  "id": 1201101,
+                  "content": "进入问题组 2 的第 1 个问题",
+                  "relatedQuestionIds": [
+                    12021
+                  ],
+                  "mutexOptionIds": [],
+                  "optionGroup": 0
+                },
+                {
+                  "id": 1201102,
+                  "content": "进入问题组 2 的第 2 个问题",
+                  "relatedQuestionIds": [
+                    12022
+                  ],
+                  "mutexOptionIds": [],
+                  "optionGroup": 0
+                },
+                {
+                  "id": 1201103,
+                  "content": "隐藏问题组 2",
+                  "relatedQuestionIds": [
+                    12020
+                  ],
+                  "mutexOptionIds": [],
+                  "optionGroup": 0
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": 1202,
+          "questionnaireId": 12,
+          "order": 2,
+          "initialQuestionId": 12020,
+          "questions": [
+            {
+              "id": 12020,
+              "type": "Input",
+              "content": "占位问题组 2 - 第 0 个问题",
+              "introduction": "末位为 0，该问题组默认隐藏。不应在页面上直接展示。",
+              "options": []
+            },
+            {
+              "id": 12021,
+              "type": "Single",
+              "content": "占位问题组 2 - 第 1 个问题",
+              "introduction": "当 related 指向本题时，页面应展示本问题。",
+              "options": [
+                {
+                  "id": 1202101,
+                  "content": "继续",
+                  "relatedQuestionIds": [],
+                  "mutexOptionIds": [],
+                  "optionGroup": 0
+                },
+                {
+                  "id": 1202102,
+                  "content": "继续（备用）",
+                  "relatedQuestionIds": [],
+                  "mutexOptionIds": [],
+                  "optionGroup": 0
+                }
+              ]
+            },
+            {
+              "id": 12022,
+              "type": "Input",
+              "content": "占位问题组 2 - 第 2 个问题",
+              "introduction": "当 related 指向本题时，页面应展示本问题。",
+              "options": []
+            }
+          ]
+        },
+        {
+          "id": 1203,
+          "questionnaireId": 12,
+          "order": 3,
+          "initialQuestionId": 12031,
+          "questions": [
+            {
+              "id": 12031,
+              "type": "Input",
+              "content": "占位问题组 3 - 第 1 个问题",
+              "introduction": "本问题组初始问题不是第 0 个问题，因此默认展示第 1 个问题。",
+              "options": []
+            }
+          ]
+        }
+      ]
+    },
+    "optionalQuestionnaire2": {
+      "id": 13,
+      "name": "主要问卷 - 二创问卷",
+      "introduction": "新版问卷结构占位数据。",
+      "questionGroups": [
+        {
+          "id": 1301,
+          "questionnaireId": 13,
+          "order": 1,
+          "initialQuestionId": 13011,
+          "questions": [
+            {
+              "id": 13011,
+              "type": "Single",
+              "content": "占位问题组 1：请选择你要进入的后续路径",
+              "introduction": "第一个问题组必须仅有一个问题，后续合作者可在此基础上替换为正式题面。",
+              "options": [
+                {
+                  "id": 1301101,
+                  "content": "进入问题组 2 的第 1 个问题",
+                  "relatedQuestionIds": [
+                    13021
+                  ],
+                  "mutexOptionIds": [],
+                  "optionGroup": 0
+                },
+                {
+                  "id": 1301102,
+                  "content": "进入问题组 2 的第 2 个问题",
+                  "relatedQuestionIds": [
+                    13022
+                  ],
+                  "mutexOptionIds": [],
+                  "optionGroup": 0
+                },
+                {
+                  "id": 1301103,
+                  "content": "隐藏问题组 2",
+                  "relatedQuestionIds": [
+                    13020
+                  ],
+                  "mutexOptionIds": [],
+                  "optionGroup": 0
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": 1302,
+          "questionnaireId": 13,
+          "order": 2,
+          "initialQuestionId": 13020,
+          "questions": [
+            {
+              "id": 13020,
+              "type": "Input",
+              "content": "占位问题组 2 - 第 0 个问题",
+              "introduction": "末位为 0，该问题组默认隐藏。不应在页面上直接展示。",
+              "options": []
+            },
+            {
+              "id": 13021,
+              "type": "Single",
+              "content": "占位问题组 2 - 第 1 个问题",
+              "introduction": "当 related 指向本题时，页面应展示本问题。",
+              "options": [
+                {
+                  "id": 1302101,
+                  "content": "继续",
+                  "relatedQuestionIds": [],
+                  "mutexOptionIds": [],
+                  "optionGroup": 0
+                },
+                {
+                  "id": 1302102,
+                  "content": "继续（备用）",
+                  "relatedQuestionIds": [],
+                  "mutexOptionIds": [],
+                  "optionGroup": 0
+                }
+              ]
+            },
+            {
+              "id": 13022,
+              "type": "Input",
+              "content": "占位问题组 2 - 第 2 个问题",
+              "introduction": "当 related 指向本题时，页面应展示本问题。",
+              "options": []
+            }
+          ]
+        },
+        {
+          "id": 1303,
+          "questionnaireId": 13,
+          "order": 3,
+          "initialQuestionId": 13031,
+          "questions": [
+            {
+              "id": 13031,
+              "type": "Input",
+              "content": "占位问题组 3 - 第 1 个问题",
+              "introduction": "本问题组初始问题不是第 0 个问题，因此默认展示第 1 个问题。",
+              "options": []
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "extraQuestionnaire": {
+    "exQuestionnaire1": {
+      "id": 21,
+      "name": "额外问卷 1 - 同人作品相关",
+      "introduction": "新版问卷结构占位数据。",
+      "questionGroups": [
+        {
+          "id": 2101,
+          "questionnaireId": 21,
+          "order": 1,
+          "initialQuestionId": 21011,
+          "questions": [
+            {
+              "id": 21011,
+              "type": "Single",
+              "content": "占位问题组 1：请选择你要进入的后续路径",
+              "introduction": "第一个问题组必须仅有一个问题，后续合作者可在此基础上替换为正式题面。",
+              "options": [
+                {
+                  "id": 2101101,
+                  "content": "进入问题组 2 的第 1 个问题",
+                  "relatedQuestionIds": [
+                    21021
+                  ],
+                  "mutexOptionIds": [],
+                  "optionGroup": 0
+                },
+                {
+                  "id": 2101102,
+                  "content": "进入问题组 2 的第 2 个问题",
+                  "relatedQuestionIds": [
+                    21022
+                  ],
+                  "mutexOptionIds": [],
+                  "optionGroup": 0
+                },
+                {
+                  "id": 2101103,
+                  "content": "隐藏问题组 2",
+                  "relatedQuestionIds": [
+                    21020
+                  ],
+                  "mutexOptionIds": [],
+                  "optionGroup": 0
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": 2102,
+          "questionnaireId": 21,
+          "order": 2,
+          "initialQuestionId": 21020,
+          "questions": [
+            {
+              "id": 21020,
+              "type": "Input",
+              "content": "占位问题组 2 - 第 0 个问题",
+              "introduction": "末位为 0，该问题组默认隐藏。不应在页面上直接展示。",
+              "options": []
+            },
+            {
+              "id": 21021,
+              "type": "Single",
+              "content": "占位问题组 2 - 第 1 个问题",
+              "introduction": "当 related 指向本题时，页面应展示本问题。",
+              "options": [
+                {
+                  "id": 2102101,
+                  "content": "继续",
+                  "relatedQuestionIds": [],
+                  "mutexOptionIds": [],
+                  "optionGroup": 0
+                },
+                {
+                  "id": 2102102,
+                  "content": "继续（备用）",
+                  "relatedQuestionIds": [],
+                  "mutexOptionIds": [],
+                  "optionGroup": 0
+                }
+              ]
+            },
+            {
+              "id": 21022,
+              "type": "Input",
+              "content": "占位问题组 2 - 第 2 个问题",
+              "introduction": "当 related 指向本题时，页面应展示本问题。",
+              "options": []
+            }
+          ]
+        },
+        {
+          "id": 2103,
+          "questionnaireId": 21,
+          "order": 3,
+          "initialQuestionId": 21031,
+          "questions": [
+            {
+              "id": 21031,
+              "type": "Input",
+              "content": "占位问题组 3 - 第 1 个问题",
+              "introduction": "本问题组初始问题不是第 0 个问题，因此默认展示第 1 个问题。",
+              "options": []
+            }
+          ]
+        }
+      ]
+    },
+    "exQuestionnaire2": {
+      "id": 22,
+      "name": "额外问卷 2 - 官作游戏相关",
+      "introduction": "新版问卷结构占位数据。",
+      "questionGroups": [
+        {
+          "id": 2201,
+          "questionnaireId": 22,
+          "order": 1,
+          "initialQuestionId": 22011,
+          "questions": [
+            {
+              "id": 22011,
+              "type": "Single",
+              "content": "占位问题组 1：请选择你要进入的后续路径",
+              "introduction": "第一个问题组必须仅有一个问题，后续合作者可在此基础上替换为正式题面。",
+              "options": [
+                {
+                  "id": 2201101,
+                  "content": "进入问题组 2 的第 1 个问题",
+                  "relatedQuestionIds": [
+                    22021
+                  ],
+                  "mutexOptionIds": [],
+                  "optionGroup": 0
+                },
+                {
+                  "id": 2201102,
+                  "content": "进入问题组 2 的第 2 个问题",
+                  "relatedQuestionIds": [
+                    22022
+                  ],
+                  "mutexOptionIds": [],
+                  "optionGroup": 0
+                },
+                {
+                  "id": 2201103,
+                  "content": "隐藏问题组 2",
+                  "relatedQuestionIds": [
+                    22020
+                  ],
+                  "mutexOptionIds": [],
+                  "optionGroup": 0
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": 2202,
+          "questionnaireId": 22,
+          "order": 2,
+          "initialQuestionId": 22020,
+          "questions": [
+            {
+              "id": 22020,
+              "type": "Input",
+              "content": "占位问题组 2 - 第 0 个问题",
+              "introduction": "末位为 0，该问题组默认隐藏。不应在页面上直接展示。",
+              "options": []
+            },
+            {
+              "id": 22021,
+              "type": "Single",
+              "content": "占位问题组 2 - 第 1 个问题",
+              "introduction": "当 related 指向本题时，页面应展示本问题。",
+              "options": [
+                {
+                  "id": 2202101,
+                  "content": "继续",
+                  "relatedQuestionIds": [],
+                  "mutexOptionIds": [],
+                  "optionGroup": 0
+                },
+                {
+                  "id": 2202102,
+                  "content": "继续（备用）",
+                  "relatedQuestionIds": [],
+                  "mutexOptionIds": [],
+                  "optionGroup": 0
+                }
+              ]
+            },
+            {
+              "id": 22022,
+              "type": "Input",
+              "content": "占位问题组 2 - 第 2 个问题",
+              "introduction": "当 related 指向本题时，页面应展示本问题。",
+              "options": []
+            }
+          ]
+        },
+        {
+          "id": 2203,
+          "questionnaireId": 22,
+          "order": 3,
+          "initialQuestionId": 22031,
+          "questions": [
+            {
+              "id": 22031,
+              "type": "Input",
+              "content": "占位问题组 3 - 第 1 个问题",
+              "introduction": "本问题组初始问题不是第 0 个问题，因此默认展示第 1 个问题。",
+              "options": []
+            }
+          ]
+        }
+      ]
+    },
+    "exQuestionnaire3": {
+      "id": 23,
+      "name": "额外问卷 3 - 展会与手游相关",
+      "introduction": "新版问卷结构占位数据。",
+      "questionGroups": [
+        {
+          "id": 2301,
+          "questionnaireId": 23,
+          "order": 1,
+          "initialQuestionId": 23011,
+          "questions": [
+            {
+              "id": 23011,
+              "type": "Single",
+              "content": "占位问题组 1：请选择你要进入的后续路径",
+              "introduction": "第一个问题组必须仅有一个问题，后续合作者可在此基础上替换为正式题面。",
+              "options": [
+                {
+                  "id": 2301101,
+                  "content": "进入问题组 2 的第 1 个问题",
+                  "relatedQuestionIds": [
+                    23021
+                  ],
+                  "mutexOptionIds": [],
+                  "optionGroup": 0
+                },
+                {
+                  "id": 2301102,
+                  "content": "进入问题组 2 的第 2 个问题",
+                  "relatedQuestionIds": [
+                    23022
+                  ],
+                  "mutexOptionIds": [],
+                  "optionGroup": 0
+                },
+                {
+                  "id": 2301103,
+                  "content": "隐藏问题组 2",
+                  "relatedQuestionIds": [
+                    23020
+                  ],
+                  "mutexOptionIds": [],
+                  "optionGroup": 0
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": 2302,
+          "questionnaireId": 23,
+          "order": 2,
+          "initialQuestionId": 23020,
+          "questions": [
+            {
+              "id": 23020,
+              "type": "Input",
+              "content": "占位问题组 2 - 第 0 个问题",
+              "introduction": "末位为 0，该问题组默认隐藏。不应在页面上直接展示。",
+              "options": []
+            },
+            {
+              "id": 23021,
+              "type": "Single",
+              "content": "占位问题组 2 - 第 1 个问题",
+              "introduction": "当 related 指向本题时，页面应展示本问题。",
+              "options": [
+                {
+                  "id": 2302101,
+                  "content": "继续",
+                  "relatedQuestionIds": [],
+                  "mutexOptionIds": [],
+                  "optionGroup": 0
+                },
+                {
+                  "id": 2302102,
+                  "content": "继续（备用）",
+                  "relatedQuestionIds": [],
+                  "mutexOptionIds": [],
+                  "optionGroup": 0
+                }
+              ]
+            },
+            {
+              "id": 23022,
+              "type": "Input",
+              "content": "占位问题组 2 - 第 2 个问题",
+              "introduction": "当 related 指向本题时，页面应展示本问题。",
+              "options": []
+            }
+          ]
+        },
+        {
+          "id": 2303,
+          "questionnaireId": 23,
+          "order": 3,
+          "initialQuestionId": 23031,
+          "questions": [
+            {
+              "id": 23031,
+              "type": "Input",
+              "content": "占位问题组 3 - 第 1 个问题",
+              "introduction": "本问题组初始问题不是第 0 个问题，因此默认展示第 1 个问题。",
+              "options": []
+            }
+          ]
+        }
+      ]
+    },
+    "exQuestionnaire4": {
+      "id": 24,
+      "name": "额外问卷 4 - 正版盗版相关",
+      "introduction": "新版问卷结构占位数据。",
+      "questionGroups": [
+        {
+          "id": 2401,
+          "questionnaireId": 24,
+          "order": 1,
+          "initialQuestionId": 24011,
+          "questions": [
+            {
+              "id": 24011,
+              "type": "Single",
+              "content": "占位问题组 1：请选择你要进入的后续路径",
+              "introduction": "第一个问题组必须仅有一个问题，后续合作者可在此基础上替换为正式题面。",
+              "options": [
+                {
+                  "id": 2401101,
+                  "content": "进入问题组 2 的第 1 个问题",
+                  "relatedQuestionIds": [
+                    24021
+                  ],
+                  "mutexOptionIds": [],
+                  "optionGroup": 0
+                },
+                {
+                  "id": 2401102,
+                  "content": "进入问题组 2 的第 2 个问题",
+                  "relatedQuestionIds": [
+                    24022
+                  ],
+                  "mutexOptionIds": [],
+                  "optionGroup": 0
+                },
+                {
+                  "id": 2401103,
+                  "content": "隐藏问题组 2",
+                  "relatedQuestionIds": [
+                    24020
+                  ],
+                  "mutexOptionIds": [],
+                  "optionGroup": 0
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": 2402,
+          "questionnaireId": 24,
+          "order": 2,
+          "initialQuestionId": 24020,
+          "questions": [
+            {
+              "id": 24020,
+              "type": "Input",
+              "content": "占位问题组 2 - 第 0 个问题",
+              "introduction": "末位为 0，该问题组默认隐藏。不应在页面上直接展示。",
+              "options": []
+            },
+            {
+              "id": 24021,
+              "type": "Single",
+              "content": "占位问题组 2 - 第 1 个问题",
+              "introduction": "当 related 指向本题时，页面应展示本问题。",
+              "options": [
+                {
+                  "id": 2402101,
+                  "content": "继续",
+                  "relatedQuestionIds": [],
+                  "mutexOptionIds": [],
+                  "optionGroup": 0
+                },
+                {
+                  "id": 2402102,
+                  "content": "继续（备用）",
+                  "relatedQuestionIds": [],
+                  "mutexOptionIds": [],
+                  "optionGroup": 0
+                }
+              ]
+            },
+            {
+              "id": 24022,
+              "type": "Input",
+              "content": "占位问题组 2 - 第 2 个问题",
+              "introduction": "当 related 指向本题时，页面应展示本问题。",
+              "options": []
+            }
+          ]
+        },
+        {
+          "id": 2403,
+          "questionnaireId": 24,
+          "order": 3,
+          "initialQuestionId": 24031,
+          "questions": [
+            {
+              "id": 24031,
+              "type": "Input",
+              "content": "占位问题组 3 - 第 1 个问题",
+              "introduction": "本问题组初始问题不是第 0 个问题，因此默认展示第 1 个问题。",
+              "options": []
+            }
+          ]
+        }
+      ]
+    },
+    "exQuestionnaire5": {
+      "id": 25,
+      "name": "额外问卷 5 - 主办方附加",
+      "introduction": "新版问卷结构占位数据。",
+      "questionGroups": [
+        {
+          "id": 2501,
+          "questionnaireId": 25,
+          "order": 1,
+          "initialQuestionId": 25011,
+          "questions": [
+            {
+              "id": 25011,
+              "type": "Single",
+              "content": "占位问题组 1：请选择你要进入的后续路径",
+              "introduction": "第一个问题组必须仅有一个问题，后续合作者可在此基础上替换为正式题面。",
+              "options": [
+                {
+                  "id": 2501101,
+                  "content": "进入问题组 2 的第 1 个问题",
+                  "relatedQuestionIds": [
+                    25021
+                  ],
+                  "mutexOptionIds": [],
+                  "optionGroup": 0
+                },
+                {
+                  "id": 2501102,
+                  "content": "进入问题组 2 的第 2 个问题",
+                  "relatedQuestionIds": [
+                    25022
+                  ],
+                  "mutexOptionIds": [],
+                  "optionGroup": 0
+                },
+                {
+                  "id": 2501103,
+                  "content": "隐藏问题组 2",
+                  "relatedQuestionIds": [
+                    25020
+                  ],
+                  "mutexOptionIds": [],
+                  "optionGroup": 0
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": 2502,
+          "questionnaireId": 25,
+          "order": 2,
+          "initialQuestionId": 25020,
+          "questions": [
+            {
+              "id": 25020,
+              "type": "Input",
+              "content": "占位问题组 2 - 第 0 个问题",
+              "introduction": "末位为 0，该问题组默认隐藏。不应在页面上直接展示。",
+              "options": []
+            },
+            {
+              "id": 25021,
+              "type": "Single",
+              "content": "占位问题组 2 - 第 1 个问题",
+              "introduction": "当 related 指向本题时，页面应展示本问题。",
+              "options": [
+                {
+                  "id": 2502101,
+                  "content": "继续",
+                  "relatedQuestionIds": [],
+                  "mutexOptionIds": [],
+                  "optionGroup": 0
+                },
+                {
+                  "id": 2502102,
+                  "content": "继续（备用）",
+                  "relatedQuestionIds": [],
+                  "mutexOptionIds": [],
+                  "optionGroup": 0
+                }
+              ]
+            },
+            {
+              "id": 25022,
+              "type": "Input",
+              "content": "占位问题组 2 - 第 2 个问题",
+              "introduction": "当 related 指向本题时，页面应展示本问题。",
+              "options": []
+            }
+          ]
+        },
+        {
+          "id": 2503,
+          "questionnaireId": 25,
+          "order": 3,
+          "initialQuestionId": 25031,
+          "questions": [
+            {
+              "id": 25031,
+              "type": "Input",
+              "content": "占位问题组 3 - 第 1 个问题",
+              "introduction": "本问题组初始问题不是第 0 个问题，因此默认展示第 1 个问题。",
+              "options": []
+            }
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
把 `renko_dev` 累积的 10 个提交合入 `dev`。63 个文件，+1233/−264。

## ⚠️ 合并即发生产

`dev` 分支的 push 会触发 `vote-ci.yml` 与 `navigator-ci.yml` → **Build and Deploy to Vercel**，也就是公开站 `vote.thwiki.cc`。另外三个 image workflow 会同时部署到测试机。合之前请确认时机。

`dev` 当前**无分支保护**，所以这个 PR 是唯一的闸。

## 改动构成

| 作者 | 提交 | 内容 |
|---|---|---|
| Renko6626 | `8eaae1f` | **修复 `pnpm dev` 连不上后端**（详见下节） |
| Renko6626 | `3d82026` | `result-image.yml` 触发分支加 `renko_dev` |
| Renko6626 | `e3a1a9d` | 站点标题届数动态化，静态 title 去届数防过期 |
| Renko6626 | `905ca0b` | result 届数/开票时刻收敛到 shared 常量（`voteYear=12`） |
| zfqxuz | `ae0efbc` | 全模块静态代码审查，修复 40+ bug |
| zfqxuz | `72fbc65` | 改用后端返回的 `candidateId` |
| zfqxuz | `7f26460` + `de7c3d3` | vote nginx 加 gzip/超时/重试；resolver 与变量式 proxy_pass 已 revert |
| zfqxuz | `752e9c1` | 添加 `characterListLeft` 诊断日志 |

按包分布：`packages/vote` 31 / `packages/result` 25 / `packages/shared` 3 / 其余 4。

## `8eaae1f` — dev proxy 修复

v12 迁移只改了三处路由配置中的两处：`apiPrefix.ts` 切到 `/v12-be` ✅、`Dockerfile.vote.template` 的 nginx v12 块 ✅、**`vite.config.ts` 的 dev proxy ❌ 自 2026-06-01 起零改动**。

后果是 dev 下 `/v12-be/*` 无规则匹配 → Vite 走 SPA fallback → 返回 `200 + index.html`，前端 `res.json()` 解析 HTML 失败。**它不报连接错误，所以表现得像后端挂了。**

次因：唯一存在的 `/v11-be` 规则被 `b63a852` 从 `https://touhou.ai/vote-be` 改成 `http://localhost/vote-be`，本机 :80 无服务。因 `server.proxy` 只影响 dev、对构建产物零影响，CI 一直是绿的。

改动：vote 补四条 `/v12-be` 规则逐条对齐 nginx；result 的 `/res-be` 从老 Rust 生产后端改指 Python 后端（result 页面已按 Python 契约层重写，老 Rust 无那 12 个 `query*`）；navigator 删除残留的 `/nav-be`。后端地址走 `VITE_DEV_BACKEND`，默认测试机。

> **这部分对生产零风险**：只动 `server.proxy`，`vite build` 完全不读它，构建产物不变。

起 dev server 逐条实测：`/v12-be/graphql` → Strawberry GraphiQL；`vote-objects/*`、`questionnaire/structure` → 200 JSON；`POST /user-token-status` → `{"status":"invalid",...}` 契约正确；`POST /doujin/api` → `422 Field required: url`（确已到 `scraper/scrape`）；result `/res-be/graphql` → 12 个 `query*` 齐全。

## 🔍 两处请 reviewer 确认（均属 zfq 的提交，本 PR 未改动）

1. **`packages/vote/src/vote-character/lib/characterList.ts:24`** 仍有 `console.warn('[DEBUG characterListLeft] EMPTY!', ...)`。仅在列表为空时触发、不是无条件刷屏，但带 `[DEBUG]` 前缀发到公开站是否合适请确认。
2. **仓库根目录新增 `questionnaire-placeholder.json`（878 行）**，由 `ae0efbc` 引入，**源码零引用**。若它是一次性的 admin 导入素材，可能不该留在仓库根。

## 兼容性

无接口/契约变更。`shared/data/voteYear.ts` 新增常量，届数由分散硬编码收敛到单点。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WoRuWf4CSgaymU8iKSwS2Z